### PR TITLE
docs: add link to original repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # jsx-readme-test-fixture
-This repo is a test fixture for the integration test of dbartholomae/jsx-readme
+This repo is a test fixture for the integration test of [dbartholomae/jsx-readme](https://github.com/dbartholomae/jsx-readme)


### PR DESCRIPTION
This PR updates README with link to original repository.
This will also result in me being a contributor to this repository, in which is required for the integration test used in [dbartholomae/jsx-readme](https://github.com/dbartholomae/jsx-readme).